### PR TITLE
do some refactor on build process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,7 +140,7 @@ module.exports = function(grunt) {
         exec: {
             'webpack-dev': `${path.resolve('./node_modules/.bin/webpack')} --config-name dev`,
             'webpack-prod': `${path.resolve('./node_modules/.bin/webpack')} --config-name prod`,
-            'webpack-electron': `${path.resolve('./node_modules/.bin/webpack')} --config-name electron`,
+            'webpack-electron': `${path.resolve('./node_modules/.bin/webpack')} --config webpack.electron.config`,
             'webpack-all': `${path.resolve('./node_modules/.bin/webpack')}`,
         },
         sass: {
@@ -338,14 +338,7 @@ module.exports = function(grunt) {
     grunt.registerTask('build-dev', ['clean:intermediates', 'exec:webpack-dev', 'build-assets', 'drop:dev']);
     grunt.registerTask('build-prod', ['clean:intermediates', 'exec:webpack-prod', 'build-assets', 'drop:production']);
     grunt.registerTask('build-electron', ['clean:intermediates', 'exec:webpack-electron', 'build-assets', 'drop:electron']);
-    grunt.registerTask('build-all', [
-        'clean:intermediates',
-        'exec:webpack-all',
-        'build-assets',
-        'drop:dev',
-        'drop:electron',
-        'release-drops',
-    ]);
+    grunt.registerTask('build-all', ['clean:intermediates', 'exec:webpack-all', 'build-assets', 'drop:dev', 'release-drops']);
 
     grunt.registerTask('default', ['build-dev']);
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "format": "prettier --config prettier.config.js --write \"**/*\"",
         "format-check": "prettier --config prettier.config.js --check \"**/*\"",
         "precheckin": "npm-run-all --serial format-check tslint copyrightheaders build:all test test:e2e",
-        "start": "electron drop/electron/extension/bundle/main.bundle.js",
+        "start:electron": "electron drop/electron/extension/bundle/main.bundle.js",
         "test": "jest --projects src/tests/unit",
         "test:e2e": "jest --projects src/tests/end-to-end --runInBand",
         "tslint": "tslint -c ./tslint.json -p ./tsconfig.json",

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const path = require('path');
+const webpack = require('webpack');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
+
+const commonPlugins = [
+    new webpack.optimize.LimitChunkCountPlugin({
+        maxChunks: 1, // Must be greater than or equal to one
+        minChunkSize: 1000000,
+    }),
+    // Be warned: this plugin supports tslint, but enabling it here causes webpack to occasionally
+    // process.exit(0) in the middle of execution on mac build machines, resulting in difficult to
+    // debug build failures. We aren't quite sure why this is yet, but until it's root caused, keep
+    // tslint separate from webpack.
+    new ForkTsCheckerWebpackPlugin(),
+    new CaseSensitivePathsPlugin(),
+];
+
+const commonEntryFiles = {
+    injected: [path.resolve(__dirname, 'src/injected/stylesheet-init.ts'), path.resolve(__dirname, 'src/injected/client-init.ts')],
+    popup: path.resolve(__dirname, 'src/popup/popup-init.ts'),
+    insights: [path.resolve(__dirname, 'src/views/insights/initializer.ts')],
+    detailsView: [path.resolve(__dirname, 'src/DetailsView/details-view-initializer.ts')],
+    devtools: [path.resolve(__dirname, 'src/Devtools/dev-tool-init.ts')],
+    background: [path.resolve(__dirname, 'src/background/background-init.ts')],
+};
+
+const createCommonConfig = entry => {
+    const baseConfig = {
+        entry,
+        module: {
+            rules: [
+                {
+                    test: /\.tsx?$/,
+                    use: [
+                        {
+                            loader: 'ts-loader',
+                            options: {
+                                transpileOnly: true,
+                                experimentalWatchApi: true,
+                            },
+                        },
+                    ],
+                    exclude: ['/node_modules/'],
+                },
+            ],
+        },
+        resolve: {
+            modules: [path.resolve(__dirname, 'node_modules')],
+            extensions: ['.tsx', '.ts', '.js'],
+        },
+        plugins: commonPlugins,
+        node: {
+            setImmediate: false,
+        },
+        performance: {
+            // We allow higher-than-normal sizes because our users only have to do local fetches of our bundles
+            maxEntrypointSize: 10 * 1024 * 1024,
+            maxAssetSize: 10 * 1024 * 1024,
+        },
+    };
+
+    return baseConfig;
+};
+
+module.exports = {
+    commonEntryFiles,
+    createCommonConfig,
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,92 +2,8 @@
 // Licensed under the MIT License.
 const path = require('path');
 const webpack = require('webpack');
-const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
-
-const commonPlugins = [
-    new webpack.optimize.LimitChunkCountPlugin({
-        maxChunks: 1, // Must be greater than or equal to one
-        minChunkSize: 1000000,
-    }),
-    // Be warned: this plugin supports tslint, but enabling it here causes webpack to occasionally
-    // process.exit(0) in the middle of execution on mac build machines, resulting in difficult to
-    // debug build failures. We aren't quite sure why this is yet, but until it's root caused, keep
-    // tslint separate from webpack.
-    new ForkTsCheckerWebpackPlugin(),
-    new CaseSensitivePathsPlugin(),
-];
-
-const commonEntryFiles = {
-    injected: [path.resolve(__dirname, 'src/injected/stylesheet-init.ts'), path.resolve(__dirname, 'src/injected/client-init.ts')],
-    popup: path.resolve(__dirname, 'src/popup/popup-init.ts'),
-    insights: [path.resolve(__dirname, 'src/views/insights/initializer.ts')],
-    detailsView: [path.resolve(__dirname, 'src/DetailsView/details-view-initializer.ts')],
-    devtools: [path.resolve(__dirname, 'src/Devtools/dev-tool-init.ts')],
-    background: [path.resolve(__dirname, 'src/background/background-init.ts')],
-};
-
-const electronEntryFiles = {
-    main: [path.resolve(__dirname, 'src/electron/main/main.ts')],
-    injected: [path.resolve(__dirname, 'src/injected/stylesheet-init.ts'), path.resolve(__dirname, 'src/injected/client-init.ts')],
-};
-
-const createCommonConfig = entry => {
-    const baseConfig = {
-        entry,
-        module: {
-            rules: [
-                {
-                    test: /\.tsx?$/,
-                    use: [
-                        {
-                            loader: 'ts-loader',
-                            options: {
-                                transpileOnly: true,
-                                experimentalWatchApi: true,
-                            },
-                        },
-                    ],
-                    exclude: ['/node_modules/'],
-                },
-            ],
-        },
-        resolve: {
-            modules: [path.resolve(__dirname, 'node_modules')],
-            extensions: ['.tsx', '.ts', '.js'],
-        },
-        plugins: commonPlugins,
-        node: {
-            setImmediate: false,
-        },
-        performance: {
-            // We allow higher-than-normal sizes because our users only have to do local fetches of our bundles
-            maxEntrypointSize: 10 * 1024 * 1024,
-            maxAssetSize: 10 * 1024 * 1024,
-        },
-    };
-
-    return baseConfig;
-};
-
-const electronConfig = {
-    ...createCommonConfig(electronEntryFiles, true),
-    name: 'electron',
-    mode: 'development',
-    output: {
-        path: path.join(__dirname, 'extension/electronBundle'),
-        filename: '[name].bundle.js',
-    },
-    node: {
-        __dirname: false,
-        __filename: false,
-    },
-    optimization: {
-        splitChunks: false,
-    },
-    target: 'electron-main',
-};
+const { commonEntryFiles, createCommonConfig } = require('./webpack.common.config');
 
 const devConfig = {
     ...createCommonConfig(commonEntryFiles),
@@ -133,4 +49,4 @@ const prodConfig = {
 };
 
 // Use "webpack --config-name dev", "webpack --config-name prod" or "webpack --config-name electron" to use just one or the other
-module.exports = [devConfig, prodConfig, electronConfig];
+module.exports = [devConfig, prodConfig];

--- a/webpack.electron.config.js
+++ b/webpack.electron.config.js
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const path = require('path');
+const webpack = require('webpack');
+const { createCommonConfig } = require('./webpack.common.config');
+
+const electronEntryFiles = {
+    main: [path.resolve(__dirname, 'src/electron/main/main.ts')],
+    injected: [path.resolve(__dirname, 'src/injected/stylesheet-init.ts'), path.resolve(__dirname, 'src/injected/client-init.ts')],
+};
+
+const electronConfig = {
+    ...createCommonConfig(electronEntryFiles, true),
+    name: 'electron',
+    mode: 'development',
+    output: {
+        path: path.join(__dirname, 'extension/electronBundle'),
+        filename: '[name].bundle.js',
+    },
+    node: {
+        __dirname: false,
+        __filename: false,
+    },
+    optimization: {
+        splitChunks: false,
+    },
+    target: 'electron-main',
+};
+
+module.exports = [electronConfig];


### PR DESCRIPTION
#### Description of changes

- Creates separate Webpack configs for common part to make it easier to import that stuff.
- also changed name of start to start-electron to make it more descriptive, let me know if you dont like it. Will change.
- webpack:all now only does what it was doing before; so we are not adding extra load on our release process with these electron changes.